### PR TITLE
bigImage is now shows a pointer cursor

### DIFF
--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -12,6 +12,10 @@
     margin: 0 auto;
 }
 
+.bigImage {
+    cursor: pointer;
+}
+
 .site small {
     font-size: 70%;
 }


### PR DESCRIPTION
## What

the css now has a selector for specifically the bigImage, giving it a pointer cursor (the same you get when mousing over links and other clickables)

## Why

I think it's best explained with an image

<details>
  <summary>Before</summary>
  
  ![image](https://user-images.githubusercontent.com/40974010/146660610-404c3c30-b29f-4fe0-9c18-22bc8a3a2979.png)
  
</details>

<details>
  <summary>After</summary>
  Pretend the very dumb mickey mouse cursor 
  
  ![image](https://user-images.githubusercontent.com/40974010/146660803-56995267-533c-4d7a-a75d-88244cb1ffe5.png)
  
</details>
