### PR TITLE
Fix DATABASE_TYPE for sqlite in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ One of the following variable sets are needed to configure the database:
 
 If using SQLite:
 
-- `DATABASE_TYPE=sqlite`
+- `DATABASE_TYPE=sqlite3`
 - `SQLITE_DB_PATH=./data.db`
 
 If using Postgres:


### PR DESCRIPTION
According to [`server/data_source.js`](https://github.com/saplinganon/imissfauna.com/blob/7643717adbc6e176aa6c83ad8ab4be60fddd66c3/server/data_sources.js#L105C1-L105C1), the correct value for `DATABASE_TYPE` when using sqlite is `sqlite3`, not `sqlite`. Using `sqlite` (or any other string) defaults to using postgresql instead, instead of throwing an error, which may be confusing.

This pull request only corrects this discrepancy in `README.md`, though the server should probably error out if the env variable is set to an unexpected value.